### PR TITLE
feat: Add SCSS support for scoped styles in Vue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,23 @@ function configBuilder(addon_name, entrypoints) {
           ],
         },
         {
+          test: /\.(scss|css)$/,
+          use: [
+            'style-loader',
+            'css-loader'
+          ]
+        },
+        {
+          test: /\.scss$/,
+          loader: 'sass-loader',
+          options: {
+            additionalData:
+              `@import "@demos-europe/demosplan-ui/tokens/scss/_color.scss";
+              @import "@demos-europe/demosplan-ui/tokens/scss/_fontSize.scss";
+              @import "@demos-europe/demosplan-ui/tokens/scss/_space.scss";`
+          }
+        },
+        {
           test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
           type: 'asset',
         },


### PR DESCRIPTION
To enable the usage of scoped styles in vue compoents for our addon-system we have to add some loader.
And to enable the usage of demosplan-ui scss vars, we have to import them here aswell