### PR TITLE
feat: add param to disable code minimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+**Feature**
+
+- Add param to disable code minimization
+
 ## v0.0.5 - 19-05-2023
 
 **Fixes**

--- a/src/index.js
+++ b/src/index.js
@@ -32,9 +32,10 @@ function resolve (dir) {
  *
  * @param {String} addon_name the name, d'uh
  * @param {Object} entrypoints name-mapped entry points dictionary
+ * @param {Boolean} minimize disable code minimization
  * @returns {Options} webpack configuration
  */
-function configBuilder(addon_name, entrypoints) {
+function configBuilder(addon_name, entrypoints, minimize = true) {
   const isProduction = process.env.NODE_ENV == 'production'
 
   /**
@@ -66,6 +67,9 @@ function configBuilder(addon_name, entrypoints) {
     },
     resolve: {
       extensions: ['.js', '.vue']
+    },
+    optimization: {
+      minimize: minimize
     },
     devtool: isProduction ? 'nosources-source-map': 'eval-source-map',
     plugins: [


### PR DESCRIPTION
Since it currently is a little bit troublesome to build certain addons, we can implement a hotfix here to disable code minimization to make certain addons installable again. Since not all addons are affected, we only need the option to disable code minimization to overrule the default.

Somehow an error occurs now when installing certain addons. I could find out the problem was a re-declaration of a variable in the minified code on production builds. However I could also find out that a workaround for this problem is to disable the code minimization hence the original variable names are going to be used instead of the minified letters.

I was not able to determine why this error occurred in the first place but could find a working solution which is this one.
