### PR TITLE
fix: declare webpack as a peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- Declare `webpack` as a `peerDependency` so the consuming addon always supplies a single webpack copy. Previously webpack was only a `devDependency`, which happened to work via hoisting but was neither explicit nor enforced: when a consumer's webpack version diverged from the one resolved for the plugins imported here (`webpack-assets-manifest`, `mini-css-extract-plugin`, `vue-loader`), a second webpack copy could be installed. That made `webpack-assets-manifest` throw `The 'compilation' argument must be an instance of Compilation` and aborted the addon UI build before `dist/` was written.
+
 ## v0.0.13 - 26-06-2025
 
 - Add packages imported directly in index.js to the dependencies section of package.json ([#251](https://github.com/demos-europe/demosplan-js-addon/pull/251))

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "vue-loader": "^16.8.3",
     "webpack-assets-manifest": "^5.1.0"
   },
+  "peerDependencies": {
+    "webpack": "^5.75.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.20.5",
     "@babel/preset-env": "^7.20.2",


### PR DESCRIPTION
## What
Add `webpack` to `peerDependencies` (`^5.75.0`). It stays in `devDependencies` for local use.

## Why
This package produces a webpack config and instantiates webpack plugins (`webpack-assets-manifest`, `mini-css-extract-plugin`, `vue-loader`) that all declare `webpack` as a **peerDependency**. The consuming addon is what actually runs webpack. So the correct contract is: the consumer supplies exactly one webpack, and this package declares it as a peer.

Previously webpack was only a `devDependency`. That happened to work because the consumer's webpack got hoisted and the plugins resolved it — but the requirement was implicit and unenforced. When a consumer's top-level webpack version diverged from the version the lockfile had pinned for the plugins here, a **second webpack copy** was installed. `webpack-assets-manifest` then bound its `Compilation`/`NormalModule` classes to one copy while the build ran on the other, so the `instanceof` guard failed:

```
TypeError: The 'compilation' argument must be an instance of Compilation
```

The build aborted before writing `dist/assets-manifest.json`, which then made demosplan fail at boot loading the addon's UI manifest.

## Effect
Declaring `webpack` as a peerDependency makes the single-webpack requirement explicit and enforced (package managers warn on a missing/mismatched peer), so a divergent consumer webpack can no longer silently produce a duplicate copy. Older consumers that still resolve a stale version of this package should also bump to pick up the change.