### PR TITLE
feat: Allow esm builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 - Declare `webpack` as a `peerDependency` so the consuming addon always supplies a single webpack copy. Previously webpack was only a `devDependency`, which happened to work via hoisting but was neither explicit nor enforced: when a consumer's webpack version diverged from the one resolved for the plugins imported here (`webpack-assets-manifest`, `mini-css-extract-plugin`, `vue-loader`), a second webpack copy could be installed. That made `webpack-assets-manifest` throw `The 'compilation' argument must be an instance of Compilation` and aborted the addon UI build before `dist/` was written.
+- **Breaking:** Build output switched from UMD/`window`-global bundles (`[name].umd.js`) to real ES modules (`[name].esm.js`), so consumers can `import()` addon entrypoints directly instead of `eval()`-ing fetched source and reading a global. Requires `demosplan-core` to serve addon assets by URL rather than embedding source in the RPC response.
 
 ## v0.0.13 - 26-06-2025
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ function resolve (dir) {
  * )
  * ```
  *
- * @param {String} addon_name the name, d'uh
+ * @param {String} addon_name kept for call-site compatibility; ES module output has no named global to attach, so it's unused here
  * @param {Object} entrypoints name-mapped entry points dictionary
  * @returns {Options} webpack configuration
  */
@@ -51,18 +51,20 @@ function configBuilder(addon_name, entrypoints) {
       import: entrypoints[key]
     }
     entrypoints[key]['library'] = {
-      name: key,
-      type: 'window'
+      type: 'module'
     }
   }
 
   return {
     entry: entrypoints,
     mode: isProduction ? 'production' : 'development',
+    experiments: {
+      outputModule: true
+    },
     output: {
       path: resolve('dist'),
-      filename: `[name].umd.js`,
-      library: addon_name
+      filename: `[name].esm.js`,
+      module: true
     },
     resolve: {
       extensions: ['.js', '.vue']


### PR DESCRIPTION
Build output switched from UMD/`window`-global bundles (`[name].umd.js`) to real ES modules (`[name].esm.js`), so consumers can `import()` addon entrypoints directly instead of `eval()`-ing fetched source and reading a global. Requires `demosplan-core` to serve addon assets by URL rather than embedding source in the RPC response.

Besides allowing us to eventually – once all addons are upgraded – get rid of the `eval` during addon loading in `demosplan-core`, using dynamic imports with ES modules is an important step in making addons ready to be consumed by module federation.